### PR TITLE
Add service layer unit tests

### DIFF
--- a/src/test/java/com/arya/api/usecase/imlp/OcorrenciaServiceImplTest.java
+++ b/src/test/java/com/arya/api/usecase/imlp/OcorrenciaServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.arya.api.usecase.imlp;
+
+import com.arya.api.adapter.http.dto.request.EnderecoCadastroRequest;
+import com.arya.api.adapter.http.dto.request.OcorrenciaCadastroRequest;
+import com.arya.api.adapter.http.dto.response.OcorrenciaResposta;
+import com.arya.api.adapter.repository.AreaOperacaoRepository;
+import com.arya.api.adapter.repository.OcorrenciaRepository;
+import com.arya.api.adapter.repository.UsuarioRepository;
+import com.arya.api.domain.model.Usuario;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OcorrenciaServiceImplTest {
+
+    @Autowired
+    private OcorrenciaServiceImpl ocorrenciaService;
+
+    @Autowired
+    private OcorrenciaRepository ocorrenciaRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private AreaOperacaoRepository areaOperacaoRepository;
+
+    @MockBean
+    private GeocodingService geocodingService;
+
+    @BeforeEach
+    void setup() {
+        ocorrenciaRepository.deleteAll();
+        areaOperacaoRepository.deleteAll();
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    void deveSalvarOcorrenciaComSucesso() {
+        Usuario usuario = Usuario.builder()
+                .nome("Usuario")
+                .email("teste@ex.com")
+                .senha("123")
+                .build();
+        usuario = usuarioRepository.save(usuario);
+
+        when(geocodingService.obterCoordenadas(anyString()))
+                .thenReturn(Optional.of(new double[]{10.0, 20.0}));
+
+        EnderecoCadastroRequest endereco = new EnderecoCadastroRequest();
+        endereco.setBairro("Centro");
+        endereco.setCidade("Cidade");
+        endereco.setEstado("ST");
+        endereco.setPais("BR");
+
+        OcorrenciaCadastroRequest request = new OcorrenciaCadastroRequest();
+        request.setTipoOcorrencia("Fogo");
+        request.setNivelSeveridade(1);
+        request.setDataOcorrencia(OffsetDateTime.now());
+        request.setDescricao("desc");
+        request.setIdUsuario(usuario.getUsuarioId());
+        request.setEndereco(endereco);
+
+        OcorrenciaResposta resposta = ocorrenciaService.salvar(request);
+
+        assertNotNull(resposta.getIdOcorrencia());
+        assertEquals(1, ocorrenciaRepository.count());
+    }
+}

--- a/src/test/java/com/arya/api/usecase/imlp/UsuarioServiceImplTest.java
+++ b/src/test/java/com/arya/api/usecase/imlp/UsuarioServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.arya.api.usecase.imlp;
+
+import com.arya.api.adapter.repository.UsuarioRepository;
+import com.arya.api.domain.exception.EmailJaCadastradoException;
+import com.arya.api.domain.model.Usuario;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class UsuarioServiceImplTest {
+
+    @Autowired
+    private UsuarioServiceImpl usuarioService;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @BeforeEach
+    void setup() {
+        usuarioRepository.deleteAll();
+    }
+
+    @Test
+    void deveSalvarUsuarioQuandoEmailNaoExiste() {
+        Usuario usuario = Usuario.builder()
+                .nome("Usuario")
+                .email("usuario@example.com")
+                .senha("123456")
+                .build();
+
+        Usuario salvo = usuarioService.salvar(usuario);
+
+        assertNotNull(salvo.getUsuarioId());
+        assertEquals(1, usuarioRepository.count());
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoEmailJaCadastrado() {
+        Usuario existente = Usuario.builder()
+                .nome("Existente")
+                .email("existente@example.com")
+                .senha("123")
+                .build();
+        usuarioRepository.save(existente);
+
+        Usuario novo = Usuario.builder()
+                .nome("Novo")
+                .email("existente@example.com")
+                .senha("abc")
+                .build();
+
+        assertThrows(EmailJaCadastradoException.class, () -> usuarioService.salvar(novo));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for UsuarioServiceImpl covering email validation
- add tests for OcorrenciaServiceImpl using H2 and mocked geocoding service
- ensure `test` profile is active by default with H2 configuration

## Testing
- `./mvnw test` *(fails: unable to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_683f84b2bc288332b81bbd74022e7fd7