### PR TITLE
Implement RabbitMQ queue configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,13 +128,18 @@
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>com.vladsch.flexmark</groupId>
-			<artifactId>flexmark-all</artifactId>
-			<version>0.64.0</version>
-		</dependency>
+                <dependency>
+                        <groupId>com.vladsch.flexmark</groupId>
+                        <artifactId>flexmark-all</artifactId>
+                        <version>0.64.0</version>
+                </dependency>
 
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-amqp</artifactId>
+                </dependency>
+
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/arya/api/infra/messaging/MessageConsumer.java
+++ b/src/main/java/com/arya/api/infra/messaging/MessageConsumer.java
@@ -1,0 +1,15 @@
+package com.arya.api.infra.messaging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class MessageConsumer {
+
+    @RabbitListener(queues = RabbitMQConfig.QUEUE)
+    public void receive(String message) {
+        log.info("Received message: {}", message);
+    }
+}

--- a/src/main/java/com/arya/api/infra/messaging/MessageProducer.java
+++ b/src/main/java/com/arya/api/infra/messaging/MessageProducer.java
@@ -1,0 +1,16 @@
+package com.arya.api.infra.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MessageProducer {
+
+    private final AmqpTemplate amqpTemplate;
+
+    public void send(String message) {
+        amqpTemplate.convertAndSend(RabbitMQConfig.EXCHANGE, RabbitMQConfig.ROUTING_KEY, message);
+    }
+}

--- a/src/main/java/com/arya/api/infra/messaging/RabbitMQConfig.java
+++ b/src/main/java/com/arya/api/infra/messaging/RabbitMQConfig.java
@@ -1,0 +1,48 @@
+package com.arya.api.infra.messaging;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String QUEUE = "arya.queue";
+    public static final String EXCHANGE = "arya.exchange";
+    public static final String ROUTING_KEY = "arya.routing-key";
+
+    @Bean
+    public Queue queue() {
+        return new Queue(QUEUE, true);
+    }
+
+    @Bean
+    public DirectExchange exchange() {
+        return new DirectExchange(EXCHANGE);
+    }
+
+    @Bean
+    public Binding binding(Queue queue, DirectExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+    }
+
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public AmqpTemplate amqpTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(messageConverter);
+        return template;
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -38,6 +38,12 @@ spring:
             connect-timeout: 5000
             read-timeout: 5000
 
+  rabbitmq:
+    host: localhost
+    listener:
+      simple:
+        auto-startup: false
+
 openweather:
   api-key: da377d5c2b5c5aff6622436623211cec
 


### PR DESCRIPTION
## Summary
- add RabbitMQ starter dependency
- configure queue, exchange and binding
- implement a producer and consumer
- disable auto startup for RabbitMQ during tests

## Testing
- `./mvnw test -q` *(fails: Failed to fetch maven binary)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438c25de4c833286cc7d20c9f548cd